### PR TITLE
Fixed issues with oned_config and onecluster resource

### DIFF
--- a/lib/puppet/provider/oneimage/oneimage.rb
+++ b/lib/puppet/provider/oneimage/oneimage.rb
@@ -29,8 +29,8 @@ EOF
     tempfile = template.result(binding)
     file.write(tempfile)
     file.close
-    #oneimage "register", file.path
-    debug(`su oneadmin -c 'oneimage register #{file.path}'`)
+    oneimage "register", file.path
+    # debug(`su oneadmin -c 'oneimage register #{file.path}'`)
   end
   
   # Destroy a network using onevnet delete

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -186,10 +186,14 @@ class opennebula::controller (
   ###############
   # Oned Config #
   ###############
-  $config_hash = { 
-    "opennebula::oned_conf" => $oned_config,   
+  if ($oned_config) {
+    $config_hash = { 
+      "opennebula::oned_conf" => $oned_config,   
+    }
+    create_resources("class", $config_hash)
+  } else {
+    include opennebula::oned_conf
   }
-  create_resources("class", $config_hash)
   
   ################
   # Oned Service #

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -220,8 +220,11 @@ class opennebula::controller (
   onecluster { "default":
     ensure => present,
   }
-  onecluster { $clusters: 
-    ensure => present,
+  
+  if($clusters) {
+    onecluster { $clusters: 
+      ensure => present,
+    }
   }
   
   #########


### PR DESCRIPTION
I fixed some small issues in opennebula::controller:
1. oned_conf failed if oned_config isn't set in opennebula::controller
2. opennebula::controller creates a cluster named "undef" if the parameter is empty
